### PR TITLE
Remove quotes around cmake-mode dependency.

### DIFF
--- a/cmake-font-lock.el
+++ b/cmake-font-lock.el
@@ -6,7 +6,7 @@
 ;; Keywords: faces, languages
 ;; Created: 2012-12-05
 ;; Version: 0.1.0
-;; Package-Requires: (("cmake-mode" "0.0"))
+;; Package-Requires: ((cmake-mode "0.0"))
 ;; URL: https://github.com/Lindydancer/cmake-font-lock
 
 ;; This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
This was breaking melpa's build because it's not a valid value. Not sure how it snuck through or why package.el isn't catching the error.
